### PR TITLE
Bump version to `v0.1.1` for first cargo release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vaultier"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Mathias Oertel <mathias.oertel@commercetools.com>", "Nelu Snegur <nelu.snegur@commercetools.com>"]
 description = "Crate to read secrets from Hashicorp Vault."


### PR DESCRIPTION
Repo was made public and is prepared to publish it on crates.io