### PR TITLE
Allow login to vault instead of token injection and setting secrets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "vaultier"
 version = "0.1.1"
 edition = "2021"
 authors = ["Mathias Oertel <mathias.oertel@commercetools.com>", "Nelu Snegur <nelu.snegur@commercetools.com>"]
-description = "Crate to read secrets from Hashicorp Vault."
+description = "Crate to write and read secrets from Hashicorp Vault."
 documentation = "https://docs.rs/vaultier"
 readme = "README.md"
 keywords = ["secrets", "vault", "hashicorp"]
@@ -14,3 +14,11 @@ repository = "https://github.com/commercetools/vaultier"
 [dependencies]
 serde = "1.0"
 vaultrs = "0.7"
+
+[features]
+default = ["token", "read"]
+token = []
+auth = []
+read = []
+write = []
+full = ["token", "auth", "read", "write"]

--- a/README.md
+++ b/README.md
@@ -17,13 +17,21 @@ struct MySecrets {
 let address = "<vault instance address>";
 let mount = String::from("<mount>");
 let base_path = String::from("<base_path>");
+
+// With token or default feature enabled
 let client = SecretClient::new(address, mount, base_path, None).unwrap();
+
+// With auth feature enabled
+let auth_mount = "<mount to vault auth>";
+let role = "<your role>";
+let client = SecretClient::create(address, auth_mount, role, mount, base_path).unwrap();
 
 // read secrets from that base path
 let secrets = client.read_secrets::<MySecrets>().await.unwrap();
 
 // read secrets from the passed path relative to the base path: mount/data/base_path/my-secrets
 let secrets = client.read_secrets_from::<MySecrets>("my-secrets").await.unwrap();
+
 ```
 
 ## License

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,31 @@
+use vaultrs::api::AuthInfo;
+use vaultrs::client::{VaultClient, VaultClientSettingsBuilder};
+
+use crate::error::Result;
+use crate::read_token_from;
+
+const K8S_JWT: &str = "K8S_JWT";
+const SERVICE_TOKEN_PATH: &str = "/var/run/secrets/kubernetes.io/serviceaccount/token";
+
+pub(crate) async fn login(
+    vault_address: &str,
+    auth_mount_path: &str,
+    role: &str,
+) -> Result<AuthInfo> {
+    let jwt = service_account_jwt()?;
+    let client = VaultClient::new(
+        VaultClientSettingsBuilder::default()
+            .address(vault_address)
+            .build()?,
+    )?;
+    Ok(vaultrs::auth::kubernetes::login(&client, auth_mount_path, role, &jwt).await?)
+}
+
+fn service_account_jwt() -> Result<String> {
+    let env_token = std::env::var(K8S_JWT);
+
+    match env_token {
+        Ok(token) => Ok(token),
+        Err(_) => read_token_from(SERVICE_TOKEN_PATH),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! Vaultier is a crate to read from and write secrets to Hashicorp Vault.
 //!
 //!
-//! ``` compile_fail
+//! ```compile_fail
 //! use vaultier::SecretClient;
 //!
 //! #[derive(serde::Deserialize)]
@@ -13,7 +13,14 @@
 //! let address = "<vault instance address>";
 //! let mount = String::from("<mount>");
 //! let base_path = String::from("<base_path>");
+//!
+//! // With token or default feature enabled
 //! let client = SecretClient::new(address, mount, base_path, None).unwrap();
+//!
+//! // With auth feature enabled
+//! let auth_mount = "<mount to vault auth>";
+//! let role = "<your role>";
+//! let client = SecretClient::create(address, auth_mount, role, mount, base_path).unwrap();
 //!
 //! // read secrets from that base path
 //! let secrets = client.read_secrets::<MySecrets>().await.unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! Vaultier is a crate to read secrets from Hashicorp Vault.
+//! Vaultier is a crate to read from and write secrets to Hashicorp Vault.
 //!
 //!
 //! ``` compile_fail
@@ -27,13 +27,17 @@ pub mod error;
 use std::fs::File;
 use std::io::prelude::*;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+use vaultrs::api::kv2::responses::SecretVersionMetadata;
+use vaultrs::api::AuthInfo;
 use vaultrs::client::{VaultClient, VaultClientSettingsBuilder};
 use vaultrs::kv2;
 
 use crate::error::Result;
 
-const TOKEN_PATH: &str = "/vault/secrets/token";
+const VAULT_TOKEN_PATH: &str = "/vault/secrets/token";
+const K8S_JWT: &str = "K8S_JWT";
+const SERVICE_TOKEN_PATH: &str = "/var/run/secrets/kubernetes.io/serviceaccount/token";
 
 /// A client to read secrets from Hashicorp Vault.
 ///
@@ -47,7 +51,7 @@ pub struct SecretClient {
 }
 
 impl SecretClient {
-    /// Convenience method to create a new SecretClient.
+    /// Convenience method to create a new SecretClient from a vault token.
     ///
     /// - address is the address of your Vault instance.
     /// - mount is the mount point of the KV2 secrets engine.
@@ -61,9 +65,37 @@ impl SecretClient {
     ) -> Result<SecretClient> {
         let token = match token {
             Some(token) => token,
-            None => read_vault_token(TOKEN_PATH)?,
+            None => read_token_from(VAULT_TOKEN_PATH)?,
         };
 
+        Self::create_internal(address, mount, base_path, &token)
+    }
+
+    /// Convenience method to create a new SecretClient with a login to vault.
+    ///
+    /// - address is the address of your Vault instance
+    /// - auth_mount is the mount path of the vault authentication
+    /// - mount is the mount point of the KV2 secrets engine
+    /// - base_path reflects the lowest level of where secrets are located
+    /// - role is the vault role to use for the login
+    pub async fn create(
+        address: &str,
+        auth_mount: &str,
+        mount: String,
+        base_path: String,
+        role: &str,
+    ) -> Result<SecretClient> {
+        let auth = login(address, auth_mount, role).await?;
+
+        Self::create_internal(address, mount, base_path, &auth.client_token)
+    }
+
+    fn create_internal(
+        address: &str,
+        mount: String,
+        base_path: String,
+        token: &str,
+    ) -> Result<SecretClient> {
         let client = VaultClient::new(
             VaultClientSettingsBuilder::default()
                 .address(address)
@@ -98,11 +130,59 @@ impl SecretClient {
         let secrets: A = kv2::read(&self.client, &self.mount, path).await?;
         Ok(secrets)
     }
+
+    /// Set secrets in the base path.
+    pub async fn set_secrets<A>(&self, data: &A) -> Result<SecretVersionMetadata>
+    where
+        A: Serialize,
+    {
+        self.set_secrets_internal(&self.base_path, data).await
+    }
+
+    /// Set secrets in the base path.
+    pub async fn set_secrets_in<A>(&self, path: &str, data: &A) -> Result<SecretVersionMetadata>
+    where
+        A: Serialize,
+    {
+        let path = format!("{}/{}", self.base_path, path);
+        self.set_secrets_internal(&path, data).await
+    }
+
+    pub async fn set_secrets_internal<A>(
+        &self,
+        path: &str,
+        data: &A,
+    ) -> Result<SecretVersionMetadata>
+    where
+        A: Serialize,
+    {
+        let auth_info = kv2::set(&self.client, &self.mount, path, data).await?;
+        Ok(auth_info)
+    }
 }
 
-fn read_vault_token(path: &str) -> Result<String> {
+fn read_token_from(path: &str) -> Result<String> {
     let mut file = File::open(path)?;
     let mut token = String::new();
     file.read_to_string(&mut token)?;
     Ok(token)
+}
+
+async fn login(vault_address: &str, auth_mount_path: &str, role: &str) -> Result<AuthInfo> {
+    let jwt = service_account_jwt()?;
+    let client = VaultClient::new(
+        VaultClientSettingsBuilder::default()
+            .address(vault_address)
+            .build()?,
+    )?;
+    Ok(vaultrs::auth::kubernetes::login(&client, auth_mount_path, role, &jwt).await?)
+}
+
+fn service_account_jwt() -> Result<String> {
+    let env_token = std::env::var(K8S_JWT);
+
+    match env_token {
+        Ok(token) => Ok(token),
+        Err(_) => read_token_from(SERVICE_TOKEN_PATH),
+    }
 }


### PR DESCRIPTION
To be able to use `vaultier` in search teams [search-ops](https://github.com/commercetools/search-ops/pull/134) repo, it needs to be extended to be able to create a Client by auth as well as being able to set secrets.

This PR adds those features to `vaultier` and enables to finetune what you need by structuring into 4 features: `token`, `auth`, `read`, `write`.