### PR TITLE
feat: basic version/metadata support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,8 @@ use crate::error::VaultierError;
 #[cfg(feature = "write")]
 use serde::Serialize;
 #[cfg(feature = "write")]
+use vaultrs::api::kv2::requests::SetSecretRequestOptions;
+#[cfg(feature = "write")]
 use vaultrs::api::kv2::responses::SecretVersionMetadata;
 
 use crate::error::Result;
@@ -239,8 +241,7 @@ impl SecretClient {
     where
         A: Serialize,
     {
-        use vaultrs::api::kv2::requests::SetSecretRequestOptions;
-        let path = options.path.unwrap_or(&self.base_path);
+        let path = options.path.unwrap_or_else(|| &self.base_path);
 
         let auth_info = match options.version {
             Some(cas) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,7 +249,7 @@ impl SecretClient {
                     &self.mount,
                     path,
                     &options.data,
-                    SetSecretRequestOptions { cas: cas },
+                    SetSecretRequestOptions { cas },
                 )
                 .await?
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,10 +68,10 @@ pub struct SecretClient {
 }
 
 /// option for confguring the write, the version will be used as cas value
-/// see https://developer.hashicorp.com/vault/tutorials/secrets-management/versioned-kv#step-8-check-and-set-operations
+/// also see https://developer.hashicorp.com/vault/tutorials/secrets-management/versioned-kv#step-8-check-and-set-operations
 pub struct WriteSecretOptions<'a, A> {
-    pub path: &'a str,
     pub data: A,
+    pub path: Option<&'a str>,
     pub version: Option<u32>,
 }
 
@@ -210,19 +210,20 @@ impl SecretClient {
         A: Serialize,
     {
         use vaultrs::api::kv2::requests::SetSecretRequestOptions;
+        let path = options.path.unwrap_or(&self.base_path);
 
         let auth_info = match options.version {
             Some(cas) => {
                 kv2::set_with_options(
                     &self.client,
                     &self.mount,
-                    options.path,
+                    path,
                     &options.data,
                     SetSecretRequestOptions { cas: cas },
                 )
                 .await?
             }
-            None => kv2::set(&self.client, &self.mount, options.path, &options.data).await?,
+            None => kv2::set(&self.client, &self.mount, path, &options.data).await?,
         };
 
         Ok(auth_info)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,9 +70,9 @@ pub struct SecretClient {
 /// option for confguring the write, the version will be used as cas value
 /// see https://developer.hashicorp.com/vault/tutorials/secrets-management/versioned-kv#step-8-check-and-set-operations
 pub struct WriteSecretOptions<'a, A> {
-    path: &'a str,
-    data: A,
-    version: Option<u32>,
+    pub path: &'a str,
+    pub data: A,
+    pub version: Option<u32>,
 }
 
 impl SecretClient {


### PR DESCRIPTION
this adds support to get the vault metadata when reading a secret and to specify a version when setting a secret. 
useful to avoid concurrent writes (especially since there is no patch support yet) and to make decisions during the update process.

relevant vault docs: https://developer.hashicorp.com/vault/tutorials/secrets-management/versioned-kv#step-8-check-and-set-operations