### PR TITLE
Remove boilerplate in favor of `thiserror`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ repository = "https://github.com/commercetools/vaultier"
 [dependencies]
 serde = "1.0"
 vaultrs = "0.7"
+thiserror = "1.0"
 
 [features]
 default = ["token", "read"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,43 +1,18 @@
-use std::fmt::{Debug, Formatter};
-use std::{fmt, io};
+use std::fmt::Debug;
+use std::io;
+
+use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, VaultierError>;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum VaultierError {
-    VaultClient(vaultrs::error::ClientError),
-    VaultClientSettings(vaultrs::client::VaultClientSettingsBuilderError),
-    IO(io::Error),
+    #[error("Vault client error: {0}")]
+    VaultClient(#[from] vaultrs::error::ClientError),
+    #[error("Vault client settings error: {0}")]
+    VaultClientSettings(#[from] vaultrs::client::VaultClientSettingsBuilderError),
+    #[error("IO error: {0}")]
+    IO(#[from] io::Error),
+    #[error("Path not found: {0}")]
     PathNotFound(String),
-}
-
-impl std::error::Error for VaultierError {}
-
-impl fmt::Display for VaultierError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            VaultierError::VaultClient(e) => std::fmt::Display::fmt(e, f),
-            VaultierError::VaultClientSettings(e) => std::fmt::Display::fmt(e, f),
-            VaultierError::IO(e) => std::fmt::Display::fmt(e, f),
-            VaultierError::PathNotFound(e) => std::fmt::Display::fmt(e, f),
-        }
-    }
-}
-
-impl From<vaultrs::error::ClientError> for VaultierError {
-    fn from(vault_client_error: vaultrs::error::ClientError) -> Self {
-        VaultierError::VaultClient(vault_client_error)
-    }
-}
-
-impl From<vaultrs::client::VaultClientSettingsBuilderError> for VaultierError {
-    fn from(settingsbuilder_error: vaultrs::client::VaultClientSettingsBuilderError) -> Self {
-        VaultierError::VaultClientSettings(settingsbuilder_error)
-    }
-}
-
-impl From<io::Error> for VaultierError {
-    fn from(error: io::Error) -> Self {
-        VaultierError::IO(error)
-    }
 }


### PR DESCRIPTION
Get rid of some boilerplate error code and use `thiserror`.