### PR TITLE
[SAYP-556] Add set metadata feature

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 # Listed users will be requested for review when someone opens a pull request.
-*       @commercetools/event-store-team
+*       @commercetools/saypetabyte 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/commercetools/vaultier"
 serde = "1.0"
 vaultrs = "0.7"
 thiserror = "1.0"
-reqwest = { version = "0.11", default-features = false, features = ["json"], optional = true }
+reqwest = { version = "0.12", default-features = false, features = ["json"], optional = true }
 serde_json = { version = "1.0", optional = true }
 url = { version = "2.2", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ repository = "https://github.com/commercetools/vaultier"
 serde = "1.0"
 vaultrs = "0.7"
 thiserror = "1.0"
+reqwest = { version = "0.11", default-features = false, features = ["json"], optional = true }
+serde_json = { version = "1.0", optional = true }
+url = { version = "2.2", optional = true }
 
 [features]
 default = ["token", "read"]
@@ -22,4 +25,5 @@ token = []
 auth = []
 read = []
 write = []
-full = ["token", "auth", "read", "write"]
+metadata = ["reqwest", "serde_json", "url"]
+full = ["token", "auth", "read", "write", "metadata"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,4 +15,19 @@ pub enum VaultierError {
     IO(#[from] io::Error),
     #[error("Path not found: {0}")]
     PathNotFound(String),
+    #[cfg(feature = "metadata")]
+    #[error("Unexpected response from the Vault API: {status}. Message: {message}.")]
+    Api {
+        status: reqwest::StatusCode,
+        message: String,
+    },
+    #[cfg(feature = "metadata")]
+    #[error("Failed to send request: {0}")]
+    Reqwest(#[from] reqwest::Error),
+    #[cfg(feature = "metadata")]
+    #[error("Json related error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[cfg(feature = "metadata")]
+    #[error("Failed to parse URL: {0}")]
+    Url(#[from] url::ParseError),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,9 +32,13 @@
 #[cfg(feature = "auth")]
 mod auth;
 pub mod error;
+#[cfg(feature = "metadata")]
+pub mod metadata;
 
 use std::fs::File;
 use std::io::prelude::*;
+#[cfg(feature = "metadata")]
+use std::sync::Arc;
 
 use serde::Deserialize;
 use vaultrs::api::kv2::responses::ReadSecretMetadataResponse;
@@ -68,6 +72,10 @@ pub struct SecretClient {
     client: VaultClient,
     mount: String,
     base_path: String,
+    #[cfg(feature = "metadata")]
+    token: Arc<str>,
+    #[cfg(feature = "metadata")]
+    http_client: reqwest::Client,
 }
 
 /// Options for confguring a write, the version will be used as cas value.
@@ -97,13 +105,21 @@ impl SecretClient {
         mount: String,
         base_path: String,
         token: Option<String>,
+        #[cfg(feature = "metadata")] http_client: reqwest::Client,
     ) -> Result<SecretClient> {
         let token = match token {
             Some(token) => token,
             None => read_token_from(VAULT_TOKEN_PATH)?,
         };
 
-        Self::create_internal(address, mount, base_path, &token)
+        Self::create_internal(
+            address,
+            mount,
+            base_path,
+            &token,
+            #[cfg(feature = "metadata")]
+            http_client,
+        )
     }
 
     /// Convenience method to create a new SecretClient with a login to vault.
@@ -120,10 +136,11 @@ impl SecretClient {
         role: &str,
         mount: String,
         base_path: String,
+        #[cfg(feature = "metadata")] http_client: reqwest::Client,
     ) -> Result<SecretClient> {
         let auth = login(address, auth_mount, role).await?;
 
-        Self::create_internal(address, mount, base_path, &auth.client_token)
+        Self::create_internal(address, mount, base_path, &auth.client_token, http_client)
     }
 
     fn create_internal(
@@ -131,6 +148,7 @@ impl SecretClient {
         mount: String,
         base_path: String,
         token: &str,
+        #[cfg(feature = "metadata")] http_client: reqwest::Client,
     ) -> Result<SecretClient> {
         let client = VaultClient::new(
             VaultClientSettingsBuilder::default()
@@ -139,7 +157,15 @@ impl SecretClient {
                 .build()?,
         )?;
 
-        Ok(SecretClient { client, mount, base_path })
+        Ok(SecretClient {
+            client,
+            mount,
+            base_path,
+            #[cfg(feature = "metadata")]
+            token: Arc::from(token),
+            #[cfg(feature = "metadata")]
+            http_client,
+        })
     }
 
     /// Read secrets from the base path.
@@ -221,11 +247,7 @@ impl SecretClient {
     }
 
     #[cfg(feature = "write")]
-    pub async fn set_secrets_internal<A>(
-        &self,
-        path: &str,
-        data: &A,
-    ) -> Result<SecretVersionMetadata>
+    async fn set_secrets_internal<A>(&self, path: &str, data: &A) -> Result<SecretVersionMetadata>
     where
         A: Serialize,
     {
@@ -258,6 +280,33 @@ impl SecretClient {
         };
 
         Ok(auth_info)
+    }
+
+    #[cfg(feature = "metadata")]
+    pub async fn set_metadata(
+        &self,
+        metadata: &metadata::Metadata<'_>,
+    ) -> Result<SecretVersionMetadata> {
+        let url = url::Url::parse(&format!(
+            "{mount}/metadata/{path}",
+            mount = self.mount,
+            path = self.base_path
+        ))?;
+        metadata::set_metadata_internal(self, url, metadata).await
+    }
+
+    #[cfg(feature = "metadata")]
+    pub async fn set_metadata_in(
+        &self,
+        path: &str,
+        metadata: &metadata::Metadata<'_>,
+    ) -> Result<SecretVersionMetadata> {
+        let url = url::Url::parse(&format!(
+            "{mount}/metadata/{base_path}/{path}",
+            mount = self.mount,
+            base_path = self.base_path
+        ))?;
+        metadata::set_metadata_internal(self, url, metadata).await
     }
 }
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,0 +1,87 @@
+use std::collections::HashMap;
+
+use serde::Deserialize;
+use serde::Serialize;
+use url::Url;
+use vaultrs::api::kv2::responses::SecretVersionMetadata;
+
+use crate::error::Result;
+use crate::error::VaultierError;
+use crate::SecretClient;
+
+const VAULT_X_TOKEN: &str = "X-Vault-Token";
+
+pub(super) async fn set_metadata_internal(
+    client: &SecretClient,
+    url: Url,
+    metadata: &Metadata<'_>,
+) -> Result<SecretVersionMetadata> {
+    let response = client
+        .http_client
+        .post(url)
+        .header(VAULT_X_TOKEN, client.token.as_ref())
+        .json(metadata)
+        .send()
+        .await?;
+
+    match response.status() {
+        reqwest::StatusCode::OK => handle_ok_response(response).await,
+        status => handle_error(status, response).await,
+    }
+}
+
+async fn handle_ok_response<A>(response: reqwest::Response) -> Result<A>
+where
+    A: for<'de> Deserialize<'de>,
+{
+    let content = response.bytes().await?;
+    let cluster_details = serde_json::from_slice(&content)?;
+    Ok(cluster_details)
+}
+
+async fn handle_error<A>(status: reqwest::StatusCode, response: reqwest::Response) -> Result<A> {
+    let message = response.text().await?;
+    Err(VaultierError::Api { status, message })
+}
+
+#[derive(Serialize, Debug, Default)]
+pub struct Metadata<'a> {
+    // The number of versions to keep per key. If not set, the backend’s configured max version is used.
+    // Once a key has more than the configured allowed versions, the oldest version will be permanently deleted.
+    max_versions: Option<u32>,
+    // If true, the key will require the cas parameter to be set on all write requests. If false,
+    // the backend’s configuration will be used.
+    cas_required: bool,
+    // Set the delete_version_after value to a duration to specify the deletion_time for all new
+    // versions written to this key. If not set, the backend's delete_version_after will be used.
+    // If the value is greater than the backend's delete_version_after, the backend's
+    // delete_version_after will be used.
+    //
+    // Accepts duration format strings: https://developer.hashicorp.com/vault/docs/concepts/duration-format
+    delete_version_after: Option<&'a str>,
+    // A map of arbitrary string to string valued user-provided metadata meant to describe the
+    // secret.
+    custom_metadata: Option<HashMap<&'a str, &'a str>>,
+}
+
+impl<'a> Metadata<'a> {
+    pub fn max_versions(mut self, max_versions: u32) -> Self {
+        self.max_versions = Some(max_versions);
+        self
+    }
+
+    pub fn cas_required(mut self, cas_required: bool) -> Self {
+        self.cas_required = cas_required;
+        self
+    }
+
+    pub fn delete_version_after(mut self, delete_version_after: &'a str) -> Self {
+        self.delete_version_after = Some(delete_version_after);
+        self
+    }
+
+    pub fn custom_metadata(mut self, custom_metadata: HashMap<&'a str, &'a str>) -> Self {
+        self.custom_metadata = Some(custom_metadata);
+        self
+    }
+}


### PR DESCRIPTION
This PR adds a feature to set Metadata of a Secret. Unfortunately `vaultrs` does not handle setting of custom metadata, somehow, so we call the API directly.